### PR TITLE
Update createJJFormat.R

### DIFF
--- a/R/createJJFormat.R
+++ b/R/createJJFormat.R
@@ -71,7 +71,7 @@ createJJFormat <- function(x) {
     v = slot(st, "v")
   )
   setkey(dt, i)
-  con <- dt[, paste(j, "(", v, ")", collapse = " ") , by = key(dt)]
+  con <- dt[, paste0(j, "(", v, ")", collapse = " ") , by = key(dt)]
 
   mm$v4 <- con[["V1"]]
   jj[[5]] <- mm


### PR DESCRIPTION
The jj-file is used as input for the intervalle tool (among other tools). Intervalle doesn't allow for empty cells in the equation part: instead of `( -1 ) or ( 1 )` it should read as follows `(-1) or (1)`.